### PR TITLE
Add React and MUI theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Dashboard</title>
 </head>
 <body>
-  <div id="app">Hello Vite!</div>
-  <script type="module" src="/src/main.js"></script>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,8 +6,16 @@
     "build": "vite build",
     "preview": "vite preview"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@emotion/react": "^11.11.5",
+    "@emotion/styled": "^11.11.5",
+    "@mui/material": "^5.15.5",
+    "@mui/icons-material": "^5.15.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
     "vite": "^5.2.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import theme from './theme';
+
+export default function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Button variant="contained" color="primary">
+        Hello MUI
+      </Button>
+    </ThemeProvider>
+  );
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,0 @@
-import './style.css';
-
-document.querySelector('#app').textContent = 'Hello Vite!';

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './style.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,14 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#dc004e',
+    },
+  },
+});
+
+export default theme;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-export default defineConfig({});
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up React in Vite config
- install Material UI with Emotion
- create MUI theme
- wire up `App` component using MUI ThemeProvider
- update entrypoint to React

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416fdc2f1c8322a97941a399a74ebe