### PR TITLE
Improve MUI theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import Button from '@mui/material/Button';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from './theme';
@@ -8,9 +12,18 @@ export default function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Button variant="contained" color="primary">
-        Hello MUI
-      </Button>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            My Dashboard
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Container sx={{ mt: 4 }}>
+        <Button variant="contained" color="primary">
+          Hello MUI
+        </Button>
+      </Container>
     </ThemeProvider>
   );
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,12 +1,44 @@
 import { createTheme } from '@mui/material/styles';
+import { red } from '@mui/material/colors';
 
 const theme = createTheme({
   palette: {
+    mode: 'light',
     primary: {
-      main: '#1976d2',
+      main: '#556cd6',
     },
     secondary: {
-      main: '#dc004e',
+      main: '#19857b',
+    },
+    error: {
+      main: red.A400,
+    },
+    background: {
+      default: '#f5f5f5',
+      paper: '#fff',
+    },
+  },
+  typography: {
+    fontFamily: ['Roboto', 'Helvetica', 'Arial', 'sans-serif'].join(','),
+    h1: {
+      fontSize: '2rem',
+      fontWeight: 600,
+    },
+    h2: {
+      fontSize: '1.5rem',
+      fontWeight: 600,
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- upgrade Material UI theme to include palette, typography and component settings
- add a simple AppBar and container layout in the demo app

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417307de788322bed5597020850da4